### PR TITLE
bug: GED-60: Add validation for incomplete CBL code translation in import

### DIFF
--- a/product_import_cwa/models/cwa_product.py
+++ b/product_import_cwa/models/cwa_product.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from odoo import _, api, fields, models, tools
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 from .utils import PRESENCE_SELECTION, YESNO_SELECTION, XMLProductLoader, split_data
 
@@ -96,6 +96,10 @@ KEY_MAPPINGS_CWA_TO_PRODUCT = {
     "bewaartemperatuur": "storage_temperature",
     "aantaldagenhoudbaar": "use_by_days",
 }
+
+
+class IncompleteValidationError(UserError):
+    pass
 
 
 def map_key(key):
@@ -660,6 +664,12 @@ class CwaProduct(models.Model):
                 self.cblcode,
             )
             raise ValidationError(msg)
+        elif not translated_cblcode.internal_category.id:
+            msg = _(
+                "Cannot translate CBL code %s into internal category."
+                "Please change translation in translation model!"
+            ) % (self.cblcode,)
+            raise IncompleteValidationError(msg)
         else:
             extra_prod_dict["categ_id"] = translated_cblcode.internal_category.id
             extra_prod_dict["pos_categ_id"] = translated_cblcode.pos_category.id

--- a/product_import_cwa/tests/test_product_import_cwa.py
+++ b/product_import_cwa/tests/test_product_import_cwa.py
@@ -4,6 +4,8 @@ import os
 
 from odoo.tests.common import TransactionCase
 
+from odoo.addons.product_import_cwa.models.cwa_product import IncompleteValidationError
+
 
 class TestProductImportCwa(TransactionCase):
     def setUp(self):
@@ -59,6 +61,18 @@ class TestProductImportCwa(TransactionCase):
         categ = self.env["product.category"].create({"name": "Beverage"})
         wizard.cblcode_ids.write(
             dict(pos_category=pos_categ.id, internal_category=categ.id)
+        )
+        wizard.action_apply()
+
+    def translate_cblcode_incomplete(self, prod):
+        """Add dummy CBL code translation to product using wizards"""
+        wizard_obj = self.env["cwa.product.import.cblcode"]
+        wizard = wizard_obj.with_context(active_ids=prod.ids).create({})
+        pos_categ = self.env["pos.category"].create({"name": "Beverage"})
+        wizard.cblcode_ids.write(
+            dict(
+                pos_category=pos_categ.id,
+            )
         )
         wizard.action_apply()
 
@@ -146,6 +160,20 @@ class TestProductImportCwa(TransactionCase):
         self.assertEqual(self.env["cwa.product.uom"].search_count([]), 1)
         self.assertEqual(self.env["cwa.product.cblcode"].search_count([]), 1)
         self.assertEqual(self.env["cwa.vat.tax"].search_count([]), 1)
+
+    def test_product_import_with_incomplete_cbl_translation(self):
+        cwa_product_obj = self.env["cwa.product"]
+        self.import_first_file(cwa_product_obj)
+        cwa_prod = cwa_product_obj.search([("omschrijving", "=", "BOEKWEIT")])
+        self.reset_translations()
+        self.translate_brand(cwa_prod)
+        self.translate_uom(cwa_prod)
+        self.translate_cblcode_incomplete(cwa_prod)
+        self.translate_tax(cwa_prod)
+        self.create_origin()
+
+        with self.assertRaises(IncompleteValidationError):
+            cwa_prod.to_product()
 
     def test_product_import_cwa_product_to_state_imported(self):
         cwa_product_obj = self.env["cwa.product"]


### PR DESCRIPTION
Introduced a new `IncompleteValidationError` to handle cases where CBL code translations lack an internal category. Updated the `to_product` method to raise this error when CBL translation is incomplete. Added a new test case to ensure proper error handling during product import.