### PR TITLE
[ADD] eenheid field to retailer view

### DIFF
--- a/product_import_cwa/views/product_template.xml
+++ b/product_import_cwa/views/product_template.xml
@@ -154,6 +154,7 @@
                                     <field name="product_brand_id" />
                                     <field name="inhoud" />
                                     <field name="uom_id" />
+                                    <field name="eenheid" />
                                     <field name="statiegeld" />
                                     <field name="plucode" />
                                     <field name="preferred_supplier_id" />


### PR DESCRIPTION
Story is that some products like soap are in CWA as unit grams, but they sell it per piece. So they want to change the sales unit to piece, but they still want the grams visible on the shelf label and also in the retailer view.