### PR TITLE
[ADD] uom_po_id field. 

### DIFF
--- a/product_import_cwa/views/product_template.xml
+++ b/product_import_cwa/views/product_template.xml
@@ -150,10 +150,11 @@
                                     <field name="eancode" />
                                     <field name="product_variant_count" invisible="1" />
                                     <field name="categ_id" />
-                                     <field name="pos_categ_id" />
+                                    <field name="pos_categ_id" />
                                     <field name="product_brand_id" />
                                     <field name="inhoud" />
-                                    <field name="uom_id" />
+                                    <field name="uom_id" groups="uom.group_uom" options="{'no_create': True}"/>
+                                    <field name="uom_po_id" groups="uom.group_uom" options="{'no_create': True}"/>
                                     <field name="eenheid" />
                                     <field name="statiegeld" />
                                     <field name="plucode" />


### PR DESCRIPTION
If uom_id and uom_po_id have a different category, Odoo will throw an error. As a user you can respond to that error only if you have both fields available in the view, like in the regular product.template view.

In the long run it's probably best if we just integrate the two product views with each other, but maybe that's for when GW goes live. 