### PR TITLE
feat: GED-62: Add product brand field to product template view

### DIFF
--- a/product_import_cwa/views/product_template.xml
+++ b/product_import_cwa/views/product_template.xml
@@ -63,6 +63,7 @@
                     filter_domain="['|', ('product_variant_ids.name','ilike',self), ('product_variant_ids.product_template_attribute_value_ids.attribute_id.name','ilike',self)]"
                 />
                 <field name="company_id" />
+                <field name="product_brand_id" />
 
                 <group expand='0' string='Group by...'>
                     <filter


### PR DESCRIPTION
Added "product_brand_id" field to the product template search view. This enables filtering or grouping of products by their associated brand.