### PR TITLE
bug: GED-69: Fix date handling in product changes tracking.

### DIFF
--- a/product_import_cwa/models/cwa_product.py
+++ b/product_import_cwa/models/cwa_product.py
@@ -1,6 +1,7 @@
 import ftplib
 import logging
 import os
+from datetime import date
 
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError, ValidationError
@@ -284,8 +285,16 @@ class CwaProduct(models.Model):
                 old_value = getattr(supplier_info, field, None)
                 new_value = new_vals[field]
                 if old_value != new_value:
-                    changes[field] = {"old": old_value, "new": new_value}
+                    changes[field] = {
+                        "old": self._check_date_and_fix_if_date(old_value),
+                        "new": self._check_date_and_fix_if_date(new_value),
+                    }
         return changes
+
+    def _check_date_and_fix_if_date(self, value):
+        if isinstance(value, date):
+            return value.strftime("%Y-%m-%d")  # Convert date to 'YYYY-MM-DD'
+        return value
 
     @api.model
     def load_records(self, keys, data, model):

--- a/product_import_cwa/tests/data/products_test_modified.xml
+++ b/product_import_cwa/tests/data/products_test_modified.xml
@@ -53,7 +53,7 @@
   <rauwemelk>0</rauwemelk>
   <inkoopprijs>2.3</inkoopprijs>
   <consumentenprijs>3.9</consumentenprijs>
-  <ingangsdatum>2016-02-11</ingangsdatum>
+  <ingangsdatum>2017-02-11</ingangsdatum>
   </product>
   <product>
   <eancode />

--- a/product_import_cwa/tests/test_product_import_cwa.py
+++ b/product_import_cwa/tests/test_product_import_cwa.py
@@ -506,6 +506,10 @@ class TestProductImportCwa(TransactionCase):
 
         changes = {
             "consumentenprijs": {"new": 3.9, "old": 3.7},
+            "ingangsdatum": {
+                "new": "2017-02-11",
+                "old": "2016-02-11",
+            },
             "ingredients": {
                 "new": "INGREDIENTENN: BOEKWEIT, EEKHOORNS",
                 "old": "INGREDIENTEN: BOEKWEIT",
@@ -533,7 +537,7 @@ class TestProductImportCwa(TransactionCase):
             [("affected_product_id", "=", imported_product.id)]
         )
 
-        changed_fields = "inkoopprijs, consumentenprijs, ingredients"
+        changed_fields = "inkoopprijs, consumentenprijs, ingangsdatum, ingredients"
 
         self.assertEqual(changed_fields, import_result.changed_fields)
 

--- a/product_import_cwa/views/cwa_product.xml
+++ b/product_import_cwa/views/cwa_product.xml
@@ -209,7 +209,9 @@
         <field name="state">code</field>
         <field name="code">
             for record in records.filtered(lambda p: p.state == "new"):
-                record.to_product()
+                action = record.to_product()
+                if action:
+                    action
         </field>
     </record>
 


### PR DESCRIPTION
Ensure date fields in product change tracking are correctly formatted as 'YYYY-MM-DD'. Added a helper method to standardize date handling and updated related test cases and sample data.