### PR TITLE
feat: GED-44: Enable POS availability for imported products

### DIFF
--- a/product_import_cwa/models/cwa_product.py
+++ b/product_import_cwa/models/cwa_product.py
@@ -547,7 +547,7 @@ class CwaProduct(models.Model):
                 "list_price": self.consumentenprijs,
                 "seller_ids": [(0, 0, supplier_dict)],
                 "kwaliteit": self.kwaliteit,
-                "available_in_pos": False,
+                "available_in_pos": True,
                 "eenheid": self.eenheid,
                 "herkomst": self.herkomst,
                 "inhoud": self.inhoud,


### PR DESCRIPTION
This change ensures that imported products are available in the point of sale by default. It updates the "available_in_pos" field to True during product import, aligning with business requirements.