### PR TITLE
bug: GED-89: Add validation before sending products to Digi

### DIFF
--- a/product_digi_sync/models/digi_sync_base_model.py
+++ b/product_digi_sync/models/digi_sync_base_model.py
@@ -11,10 +11,14 @@ class DigiSyncBaseModel(models.AbstractModel):
 
     def send_to_digi(self):
         self.ensure_one()
-        self.with_delay().send_to_digi_directly()
+        if self.should_send_to_digi():
+            self.with_delay().send_to_digi_directly()
 
     def send_to_digi_directly(self):
         pass
+
+    def should_send_to_digi(self):
+        return True
 
     def _get_digi_client(self):
         digi_client_id = int(

--- a/product_digi_sync/models/product_origin.py
+++ b/product_digi_sync/models/product_origin.py
@@ -40,6 +40,9 @@ class ProductOrigin(DigiSyncBaseModel, models.Model):
             record.send_to_digi()
         return result
 
+    def should_send_to_digi(self):
+        return self.external_digi_id is not None
+
     def send_to_digi_directly(self):
         client = self._get_digi_client()
         if client:

--- a/product_digi_sync/tests/test_product_template.py
+++ b/product_digi_sync/tests/test_product_template.py
@@ -120,6 +120,39 @@ class ProductTemplateTestCase(DigiSyncBaseTestCase):
         self.assertEqual(mock_send_product_to_digi.called, False)
         patched_get_param.stop()
 
+    def test_it_does_not_send_the_product_to_digi_when_scale_is_false_using_func(self):
+        digi_client = self._create_digi_client()
+
+        patched_get_param = self._patch_ir_config_parameter_for_get_param(
+            "digi_client_id", digi_client.id
+        )
+        patched_get_param.start()
+        mock_send_product_to_digi = Mock()
+        patch.object(
+            DigiClient, "send_product_to_digi", mock_send_product_to_digi
+        ).start()
+        patch.object(DigiClient, "send_product_image_to_digi", Mock()).start()
+
+        product1 = self.env["product.template"].create(
+            {
+                "name": "Test Product Template",
+                "shop_plucode": 405,
+                "send_to_scale": False,
+            }
+        )
+
+        products = self.env["product.template"].browse([product1.id])
+
+        products.write(
+            {
+                "name": "Test Product Template",
+            }
+        )
+        products.send_to_digi()
+
+        self.assertEqual(mock_send_product_to_digi.called, False)
+        patched_get_param.stop()
+
     def test_it_sends_the_product_image_to_digi_when_the_image_is_set(self):
         digi_client = self._create_digi_client()
 


### PR DESCRIPTION
Ensure products are sent to Digi only if they meet certain criteria by introducing `should_send_to_digi` checks. Updated related tests to verify that products with `send_to_scale` set to False are not sent to Digi.